### PR TITLE
Update lambda functions core-libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2025-03-09 [PR#19](https://github.com/OpenWorkspace-o1/aws-aurora-pgvector-extension-creator/pull/19)
+
+### Updated
+- Upgraded `esbuild` from `0.24.2` to `0.25.0` in `api-key-authorizer` lambda.
+- Updated `@aws-lambda-powertools/logger` from `^2.13.1` to `^2.16.0` and `@aws-sdk/client-secrets-manager` from `^3.738.0` to `^3.758.0`.
+- Bumped `uuid` dependency from `^11.0.5` to `^11.1.0`.
+- Incremented `api-key-authorizer-lambda` version from `0.0.2` to `0.0.3`.
+
 ## 2025-03-09 [PR#17](https://github.com/OpenWorkspace-o1/aws-aurora-pgvector-extension-creator/pull/17)
 
 ### Updated

--- a/lib/aws-aurora-pgvector-extension-endpoint-nested-stack.ts
+++ b/lib/aws-aurora-pgvector-extension-endpoint-nested-stack.ts
@@ -76,7 +76,7 @@ export class AwsAuroraPgvectorExtensionEndpointNestedStack extends NestedStack {
                 minify: true,
                 sourceMap: true,
                 sourcesContent: false,
-                esbuildVersion: '0.24.2',
+                esbuildVersion: '0.25.0',
                 target: 'ES2022',
                 format: OutputFormat.ESM,
                 forceDockerBundling: true,

--- a/src/lambdas/api-key-authorizer/package-lock.json
+++ b/src/lambdas/api-key-authorizer/package-lock.json
@@ -1,23 +1,23 @@
 {
     "name": "api-key-authorizer-lambda",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "api-key-authorizer-lambda",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "dependencies": {
-                "@aws-lambda-powertools/logger": "^2.13.1",
-                "@aws-sdk/client-secrets-manager": "^3.738.0",
+                "@aws-lambda-powertools/logger": "^2.16.0",
+                "@aws-sdk/client-secrets-manager": "^3.758.0",
                 "@types/aws-lambda": "^8.10.147",
                 "http-status-codes": "^2.3.0",
                 "util": "^0.12.5",
-                "uuid": "^11.0.5"
+                "uuid": "^11.1.0"
             },
             "devDependencies": {
                 "@types/uuid": "^10.0.0",
-                "esbuild": "^0.24.2"
+                "esbuild": "^0.25.0"
             }
         },
         "node_modules/@aws-crypto/sha256-browser": {
@@ -146,18 +146,18 @@
             }
         },
         "node_modules/@aws-lambda-powertools/commons": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.13.1.tgz",
-            "integrity": "sha512-R9y4XhFyz7KuYXwpvVonUWmVZMarKaK+4WUjG+SXkNad9m247uwIX6UM/GmliCIX0z+YpN6M9HoEBRTVofLfZw==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.16.0.tgz",
+            "integrity": "sha512-HtVibLx8yCHvfRhOwI85ghJJqF3pYr49rZP+kRyath0ZnIEWfklFmv9ehcohPzlIgaiOijKV4vyGCKiXBOnigw==",
             "license": "MIT-0"
         },
         "node_modules/@aws-lambda-powertools/logger": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.13.1.tgz",
-            "integrity": "sha512-yM93J0EO8mmmKMGJ3sbnKgeioMc1jLZVKHssagHQp/3S/NaRJp6pX4ukEFA8bq3mkMfkAtcsqTAaL6CTRKiHIA==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.16.0.tgz",
+            "integrity": "sha512-k7Xpjx1VAd/52p3Wssq83OwUFOeus6Mx9JnsXBAdAA/aUON7srbv2pPRFMGuoK9Qv5nYvADaBcL9hYtK/XknaA==",
             "license": "MIT-0",
             "dependencies": {
-                "@aws-lambda-powertools/commons": "^2.13.1",
+                "@aws-lambda-powertools/commons": "^2.16.0",
                 "lodash.merge": "^4.6.2"
             },
             "peerDependencies": {
@@ -170,45 +170,45 @@
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.738.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.738.0.tgz",
-            "integrity": "sha512-CHa55tOGnzNdkrTFA0vWI/d+5iR9s5/ARviowjp9A/qb3ykb+/vdney0iO6rNp11XIYnorlwpuqv5RRUpTPrtA==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.758.0.tgz",
+            "integrity": "sha512-Vi4cdCim0jQx3rrU5R1W4v3czoWL0ajBtoI15oSSt7cwLjzNA0xq4nXSa6rahjTgtZWlLeBprbquvxNzY3qg5Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.734.0",
-                "@aws-sdk/credential-provider-node": "3.738.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/credential-provider-node": "3.758.0",
                 "@aws-sdk/middleware-host-header": "3.734.0",
                 "@aws-sdk/middleware-logger": "3.734.0",
                 "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/region-config-resolver": "3.734.0",
                 "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
                 "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
                 "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.1",
+                "@smithy/core": "^3.1.5",
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/hash-node": "^4.0.1",
                 "@smithy/invalid-dependency": "^4.0.1",
                 "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.2",
-                "@smithy/middleware-retry": "^4.0.3",
-                "@smithy/middleware-serde": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/middleware-stack": "^4.0.1",
                 "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.3",
                 "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.2",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "@smithy/url-parser": "^4.0.1",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.3",
-                "@smithy/util-defaults-mode-node": "^4.0.3",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
                 "@smithy/util-endpoints": "^3.0.1",
                 "@smithy/util-middleware": "^4.0.1",
                 "@smithy/util-retry": "^4.0.1",
@@ -241,44 +241,44 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.734.0.tgz",
-            "integrity": "sha512-oerepp0mut9VlgTwnG5Ds/lb0C0b2/rQ+hL/rF6q+HGKPfGsCuPvFx1GtwGKCXd49ase88/jVgrhcA9OQbz3kg==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
+            "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/middleware-host-header": "3.734.0",
                 "@aws-sdk/middleware-logger": "3.734.0",
                 "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/region-config-resolver": "3.734.0",
                 "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
                 "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
                 "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.1",
+                "@smithy/core": "^3.1.5",
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/hash-node": "^4.0.1",
                 "@smithy/invalid-dependency": "^4.0.1",
                 "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.2",
-                "@smithy/middleware-retry": "^4.0.3",
-                "@smithy/middleware-serde": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/middleware-stack": "^4.0.1",
                 "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.3",
                 "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.2",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "@smithy/url-parser": "^4.0.1",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.3",
-                "@smithy/util-defaults-mode-node": "^4.0.3",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
                 "@smithy/util-endpoints": "^3.0.1",
                 "@smithy/util-middleware": "^4.0.1",
                 "@smithy/util-retry": "^4.0.1",
@@ -290,18 +290,18 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.734.0.tgz",
-            "integrity": "sha512-SxnDqf3vobdm50OLyAKfqZetv6zzwnSqwIwd3jrbopxxHKqNIM/I0xcYjD6Tn+mPig+u7iRKb9q3QnEooFTlmg==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
+            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
-                "@smithy/core": "^3.1.1",
+                "@smithy/core": "^3.1.5",
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/signature-v4": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.2",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-middleware": "^4.0.1",
                 "fast-xml-parser": "4.4.1",
@@ -312,12 +312,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.734.0.tgz",
-            "integrity": "sha512-gtRkzYTGafnm1FPpiNO8VBmJrYMoxhDlGPYDVcijzx3DlF8dhWnowuSBCxLSi+MJMx5hvwrX2A+e/q0QAeHqmw==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
+            "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -328,20 +328,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.734.0.tgz",
-            "integrity": "sha512-JFSL6xhONsq+hKM8xroIPhM5/FOhiQ1cov0lZxhzZWj6Ai3UAjucy3zyIFDr9MgP1KfCYNdvyaUq9/o+HWvEDg==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
+            "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.3",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.2",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.0.2",
+                "@smithy/util-stream": "^4.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -349,18 +349,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.734.0.tgz",
-            "integrity": "sha512-HEyaM/hWI7dNmb4NhdlcDLcgJvrilk8G4DQX6qz0i4pBZGC2l4iffuqP8K6ZQjUfz5/6894PzeFuhTORAMd+cg==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
+            "integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
-                "@aws-sdk/credential-provider-env": "3.734.0",
-                "@aws-sdk/credential-provider-http": "3.734.0",
-                "@aws-sdk/credential-provider-process": "3.734.0",
-                "@aws-sdk/credential-provider-sso": "3.734.0",
-                "@aws-sdk/credential-provider-web-identity": "3.734.0",
-                "@aws-sdk/nested-clients": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/credential-provider-env": "3.758.0",
+                "@aws-sdk/credential-provider-http": "3.758.0",
+                "@aws-sdk/credential-provider-process": "3.758.0",
+                "@aws-sdk/credential-provider-sso": "3.758.0",
+                "@aws-sdk/credential-provider-web-identity": "3.758.0",
+                "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/credential-provider-imds": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -373,17 +373,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.738.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.738.0.tgz",
-            "integrity": "sha512-3MuREsazwBxghKb2sQQHvie+uuK4dX4/ckFYiSoffzJQd0YHxaGxf8cr4NOSCQCUesWu8D3Y0SzlnHGboVSkpA==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
+            "integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.734.0",
-                "@aws-sdk/credential-provider-http": "3.734.0",
-                "@aws-sdk/credential-provider-ini": "3.734.0",
-                "@aws-sdk/credential-provider-process": "3.734.0",
-                "@aws-sdk/credential-provider-sso": "3.734.0",
-                "@aws-sdk/credential-provider-web-identity": "3.734.0",
+                "@aws-sdk/credential-provider-env": "3.758.0",
+                "@aws-sdk/credential-provider-http": "3.758.0",
+                "@aws-sdk/credential-provider-ini": "3.758.0",
+                "@aws-sdk/credential-provider-process": "3.758.0",
+                "@aws-sdk/credential-provider-sso": "3.758.0",
+                "@aws-sdk/credential-provider-web-identity": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/credential-provider-imds": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
@@ -396,12 +396,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.734.0.tgz",
-            "integrity": "sha512-zvjsUo+bkYn2vjT+EtLWu3eD6me+uun+Hws1IyWej/fKFAqiBPwyeyCgU7qjkiPQSXqk1U9+/HG9IQ6Iiz+eBw==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
+            "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -413,14 +413,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.734.0.tgz",
-            "integrity": "sha512-cCwwcgUBJOsV/ddyh1OGb4gKYWEaTeTsqaAK19hiNINfYV/DO9r4RMlnWAo84sSBfJuj9shUNsxzyoe6K7R92Q==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
+            "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.734.0",
-                "@aws-sdk/core": "3.734.0",
-                "@aws-sdk/token-providers": "3.734.0",
+                "@aws-sdk/client-sso": "3.758.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/token-providers": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -432,13 +432,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.734.0.tgz",
-            "integrity": "sha512-t4OSOerc+ppK541/Iyn1AS40+2vT/qE+MFMotFkhCgCJbApeRF2ozEdnDN6tGmnl4ybcUuxnp9JWLjwDVlR/4g==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
+            "integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
-                "@aws-sdk/nested-clients": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
+                "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -493,15 +493,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.734.0.tgz",
-            "integrity": "sha512-MFVzLWRkfFz02GqGPjqSOteLe5kPfElUrXZft1eElnqulqs6RJfVSpOV7mO90gu293tNAeggMWAVSGRPKIYVMg==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
+            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.734.0",
-                "@smithy/core": "^3.1.1",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.5",
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
@@ -511,44 +511,44 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.734.0.tgz",
-            "integrity": "sha512-iph2XUy8UzIfdJFWo1r0Zng9uWj3253yvW9gljhtu+y/LNmNvSnJxQk1f3D2BC5WmcoPZqTS3UsycT3mLPSzWA==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
+            "integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.734.0",
+                "@aws-sdk/core": "3.758.0",
                 "@aws-sdk/middleware-host-header": "3.734.0",
                 "@aws-sdk/middleware-logger": "3.734.0",
                 "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/region-config-resolver": "3.734.0",
                 "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
                 "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.758.0",
                 "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.1",
+                "@smithy/core": "^3.1.5",
                 "@smithy/fetch-http-handler": "^5.0.1",
                 "@smithy/hash-node": "^4.0.1",
                 "@smithy/invalid-dependency": "^4.0.1",
                 "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.2",
-                "@smithy/middleware-retry": "^4.0.3",
-                "@smithy/middleware-serde": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.6",
+                "@smithy/middleware-retry": "^4.0.7",
+                "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/middleware-stack": "^4.0.1",
                 "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.3",
                 "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.2",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "@smithy/url-parser": "^4.0.1",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.3",
-                "@smithy/util-defaults-mode-node": "^4.0.3",
+                "@smithy/util-defaults-mode-browser": "^4.0.7",
+                "@smithy/util-defaults-mode-node": "^4.0.7",
                 "@smithy/util-endpoints": "^3.0.1",
                 "@smithy/util-middleware": "^4.0.1",
                 "@smithy/util-retry": "^4.0.1",
@@ -577,12 +577,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.734.0.tgz",
-            "integrity": "sha512-2U6yWKrjWjZO8Y5SHQxkFvMVWHQWbS0ufqfAIBROqmIZNubOL7jXCiVdEFekz6MZ9LF2tvYGnOW4jX8OKDGfIw==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
+            "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/nested-clients": "3.734.0",
+                "@aws-sdk/nested-clients": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/property-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -607,9 +607,9 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.734.0.tgz",
-            "integrity": "sha512-w2+/E88NUbqql6uCVAsmMxDQKu7vsKV0KqhlQb0lL+RCq4zy07yXYptVNs13qrnuTfyX7uPXkXrlugvK9R1Ucg==",
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.734.0",
@@ -646,12 +646,12 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.734.0.tgz",
-            "integrity": "sha512-c6Iinh+RVQKs6jYUFQ64htOU2HUXFQ3TVx+8Tu3EDF19+9vzWi9UukhIMH9rqyyEXIAkk9XL7avt8y2Uyw2dGA==",
+            "version": "3.758.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
+            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.758.0",
                 "@aws-sdk/types": "3.734.0",
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/types": "^4.1.0",
@@ -670,9 +670,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-            "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+            "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -687,9 +687,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-            "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+            "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
             "cpu": [
                 "arm"
             ],
@@ -704,9 +704,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-            "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+            "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
             "cpu": [
                 "arm64"
             ],
@@ -721,9 +721,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-            "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+            "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
             "cpu": [
                 "x64"
             ],
@@ -738,9 +738,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-            "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+            "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
             "cpu": [
                 "arm64"
             ],
@@ -755,9 +755,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-            "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+            "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
             "cpu": [
                 "x64"
             ],
@@ -772,9 +772,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
             "cpu": [
                 "arm64"
             ],
@@ -789,9 +789,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-            "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+            "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
             "cpu": [
                 "x64"
             ],
@@ -806,9 +806,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-            "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+            "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
             "cpu": [
                 "arm"
             ],
@@ -823,9 +823,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-            "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+            "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
             "cpu": [
                 "arm64"
             ],
@@ -840,9 +840,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-            "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+            "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
             "cpu": [
                 "ia32"
             ],
@@ -857,9 +857,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-            "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+            "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
             "cpu": [
                 "loong64"
             ],
@@ -874,9 +874,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-            "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+            "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -891,9 +891,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-            "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+            "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
             "cpu": [
                 "ppc64"
             ],
@@ -908,9 +908,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-            "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+            "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
             "cpu": [
                 "riscv64"
             ],
@@ -925,9 +925,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-            "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+            "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
             "cpu": [
                 "s390x"
             ],
@@ -942,9 +942,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-            "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+            "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
             "cpu": [
                 "x64"
             ],
@@ -959,9 +959,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
             "cpu": [
                 "arm64"
             ],
@@ -976,9 +976,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+            "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
             "cpu": [
                 "x64"
             ],
@@ -993,9 +993,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-            "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+            "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
             "cpu": [
                 "arm64"
             ],
@@ -1010,9 +1010,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-            "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+            "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
             "cpu": [
                 "x64"
             ],
@@ -1027,9 +1027,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-            "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+            "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
             "cpu": [
                 "x64"
             ],
@@ -1044,9 +1044,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-            "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+            "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
             "cpu": [
                 "arm64"
             ],
@@ -1061,9 +1061,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-            "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+            "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
             "cpu": [
                 "ia32"
             ],
@@ -1078,9 +1078,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-            "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+            "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
             "cpu": [
                 "x64"
             ],
@@ -1124,9 +1124,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.2.tgz",
-            "integrity": "sha512-htwQXkbdF13uwwDevz9BEzL5ABK+1sJpVQXywwGSH973AVOvisHNfpcB8A8761G6XgHoS2kHPqc9DqHJ2gp+/Q==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
+            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/middleware-serde": "^4.0.2",
@@ -1134,7 +1134,7 @@
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-stream": "^4.0.2",
+                "@smithy/util-stream": "^4.1.2",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1229,12 +1229,12 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.3.tgz",
-            "integrity": "sha512-YdbmWhQF5kIxZjWqPIgboVfi8i5XgiYMM7GGKFMTvBei4XjNQfNv8sukT50ITvgnWKKKpOtp0C0h7qixLgb77Q==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
+            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.2",
+                "@smithy/core": "^3.1.5",
                 "@smithy/middleware-serde": "^4.0.2",
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -1248,15 +1248,15 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.4.tgz",
-            "integrity": "sha512-wmxyUBGHaYUqul0wZiset4M39SMtDBOtUr2KpDuftKNN74Do9Y36Go6Eqzj9tL0mIPpr31ulB5UUtxcsCeGXsQ==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
+            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.3",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-middleware": "^4.0.1",
                 "@smithy/util-retry": "^4.0.1",
@@ -1322,9 +1322,9 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
-            "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
+            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.1",
@@ -1435,17 +1435,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.3.tgz",
-            "integrity": "sha512-A2Hz85pu8BJJaYFdX8yb1yocqigyqBzn+OVaVgm+Kwi/DkN8vhN2kbDVEfADo6jXf5hPKquMLGA3UINA64UZ7A==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
+            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.2",
-                "@smithy/middleware-endpoint": "^4.0.3",
+                "@smithy/core": "^3.1.5",
+                "@smithy/middleware-endpoint": "^4.0.6",
                 "@smithy/middleware-stack": "^4.0.1",
                 "@smithy/protocol-http": "^5.0.1",
                 "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.0.2",
+                "@smithy/util-stream": "^4.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1542,13 +1542,13 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.4.tgz",
-            "integrity": "sha512-Ej1bV5sbrIfH++KnWxjjzFNq9nyP3RIUq2c9Iqq7SmMO/idUR24sqvKH2LUQFTSPy/K7G4sB2m8n7YYlEAfZaw==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
+            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.3",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
@@ -1558,16 +1558,16 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.4.tgz",
-            "integrity": "sha512-HE1I7gxa6yP7ZgXPCFfZSDmVmMtY7SHqzFF55gM/GPegzZKaQWZZ+nYn9C2Cc3JltCMyWe63VPR3tSFDEvuGjw==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
+            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^4.0.1",
                 "@smithy/credential-provider-imds": "^4.0.1",
                 "@smithy/node-config-provider": "^4.0.1",
                 "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.3",
+                "@smithy/smithy-client": "^4.1.6",
                 "@smithy/types": "^4.1.0",
                 "tslib": "^2.6.2"
             },
@@ -1629,13 +1629,13 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.2.tgz",
-            "integrity": "sha512-0eZ4G5fRzIoewtHtwaYyl8g2C+osYOT4KClXgfdNEDAgkbe2TYPqcnw4GAWabqkZCax2ihRGPe9LZnsPdIUIHA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
+            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.3",
                 "@smithy/types": "^4.1.0",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-buffer-from": "^4.0.0",
@@ -1815,9 +1815,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.24.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-            "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+            "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1828,31 +1828,31 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.24.2",
-                "@esbuild/android-arm": "0.24.2",
-                "@esbuild/android-arm64": "0.24.2",
-                "@esbuild/android-x64": "0.24.2",
-                "@esbuild/darwin-arm64": "0.24.2",
-                "@esbuild/darwin-x64": "0.24.2",
-                "@esbuild/freebsd-arm64": "0.24.2",
-                "@esbuild/freebsd-x64": "0.24.2",
-                "@esbuild/linux-arm": "0.24.2",
-                "@esbuild/linux-arm64": "0.24.2",
-                "@esbuild/linux-ia32": "0.24.2",
-                "@esbuild/linux-loong64": "0.24.2",
-                "@esbuild/linux-mips64el": "0.24.2",
-                "@esbuild/linux-ppc64": "0.24.2",
-                "@esbuild/linux-riscv64": "0.24.2",
-                "@esbuild/linux-s390x": "0.24.2",
-                "@esbuild/linux-x64": "0.24.2",
-                "@esbuild/netbsd-arm64": "0.24.2",
-                "@esbuild/netbsd-x64": "0.24.2",
-                "@esbuild/openbsd-arm64": "0.24.2",
-                "@esbuild/openbsd-x64": "0.24.2",
-                "@esbuild/sunos-x64": "0.24.2",
-                "@esbuild/win32-arm64": "0.24.2",
-                "@esbuild/win32-ia32": "0.24.2",
-                "@esbuild/win32-x64": "0.24.2"
+                "@esbuild/aix-ppc64": "0.25.0",
+                "@esbuild/android-arm": "0.25.0",
+                "@esbuild/android-arm64": "0.25.0",
+                "@esbuild/android-x64": "0.25.0",
+                "@esbuild/darwin-arm64": "0.25.0",
+                "@esbuild/darwin-x64": "0.25.0",
+                "@esbuild/freebsd-arm64": "0.25.0",
+                "@esbuild/freebsd-x64": "0.25.0",
+                "@esbuild/linux-arm": "0.25.0",
+                "@esbuild/linux-arm64": "0.25.0",
+                "@esbuild/linux-ia32": "0.25.0",
+                "@esbuild/linux-loong64": "0.25.0",
+                "@esbuild/linux-mips64el": "0.25.0",
+                "@esbuild/linux-ppc64": "0.25.0",
+                "@esbuild/linux-riscv64": "0.25.0",
+                "@esbuild/linux-s390x": "0.25.0",
+                "@esbuild/linux-x64": "0.25.0",
+                "@esbuild/netbsd-arm64": "0.25.0",
+                "@esbuild/netbsd-x64": "0.25.0",
+                "@esbuild/openbsd-arm64": "0.25.0",
+                "@esbuild/openbsd-x64": "0.25.0",
+                "@esbuild/sunos-x64": "0.25.0",
+                "@esbuild/win32-arm64": "0.25.0",
+                "@esbuild/win32-ia32": "0.25.0",
+                "@esbuild/win32-x64": "0.25.0"
             }
         },
         "node_modules/fast-xml-parser": {
@@ -2145,9 +2145,15 @@
             }
         },
         "node_modules/strnum": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+            "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
             "license": "MIT"
         },
         "node_modules/tslib": {
@@ -2170,9 +2176,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.0.5",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-            "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"

--- a/src/lambdas/api-key-authorizer/package.json
+++ b/src/lambdas/api-key-authorizer/package.json
@@ -1,16 +1,16 @@
 {
     "name": "api-key-authorizer-lambda",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "dependencies": {
-        "@aws-lambda-powertools/logger": "^2.13.1",
-        "@aws-sdk/client-secrets-manager": "^3.738.0",
+        "@aws-lambda-powertools/logger": "^2.16.0",
+        "@aws-sdk/client-secrets-manager": "^3.758.0",
         "@types/aws-lambda": "^8.10.147",
         "http-status-codes": "^2.3.0",
         "util": "^0.12.5",
-        "uuid": "^11.0.5"
+        "uuid": "^11.1.0"
     },
     "devDependencies": {
         "@types/uuid": "^10.0.0",
-        "esbuild": "^0.24.2"
+        "esbuild": "^0.25.0"
     }
 }

--- a/src/lambdas/rds-pg-extension-init/requirements.txt
+++ b/src/lambdas/rds-pg-extension-init/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==3.5.0
-SQLAlchemy==2.0.37
+aws-lambda-powertools==3.8.0
+SQLAlchemy==2.0.38
 pgvector==0.3.6
-psycopg[binary,pool]==3.2.4
+psycopg[binary,pool]==3.2.5


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration

___

### **PR Description**
- Updated `esbuild` version from `0.24.2` to `0.25.0` in `api-key-authorizer` lambda.

- Upgraded `@aws-lambda-powertools/logger` from `^2.13.1` to `^2.16.0` and `@aws-sdk/client-secrets-manager` from `^3.738.0` to `^3.758.0`.

- Bumped `uuid` dependency from `^11.0.5` to `^11.1.0`.

- Incremented `api-key-authorizer-lambda` version from `0.0.2` to `0.0.3`.
