### PR TITLE
Update core libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2025-03-22 [PR#23](https://github.com/OpenWorkspace-o1/aws-ow-aurora-pgvector-serverless/pull/23)
+
+### Updated
+- Upgraded `aws-cdk` from `2.1003.0` to `2.1005.0`, `aws-cdk-lib` from `2.182.0` to `2.185.0`, and `cdk-nag` from `2.35.41` to `2.35.52`.
+- Updated `@types/node` from `22.13.10` to `22.13.11`.
+- Bumped package version from `0.1.5` to `0.1.6`.
+
 ## 2025-03-09 [PR#19](https://github.com/OpenWorkspace-o1/aws-aurora-pgvector-extension-creator/pull/19)
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "aws-aurora-pgvector-extension-creator",
       "version": "0.1.5",
       "dependencies": {
-        "@aws-cdk/aws-lambda-python-alpha": "^2.182.0-alpha.0",
-        "aws-cdk-lib": "2.182.0",
-        "cdk-nag": "^2.35.41",
+        "@aws-cdk/aws-lambda-python-alpha": "^2.185.0-alpha.0",
+        "aws-cdk-lib": "2.185.0",
+        "cdk-nag": "^2.35.52",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -20,9 +20,9 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.13.10",
+        "@types/node": "22.13.11",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.1003.0",
+        "aws-cdk": "2.1005.0",
         "esbuild": "^0.25.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.6",
@@ -30,8 +30,8 @@
         "typescript": "~5.8.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.1003.0",
-        "aws-cdk-lib": "2.182.0",
+        "aws-cdk": "2.1005.0",
+        "aws-cdk-lib": "2.185.0",
         "constructs": "^10.4.2"
       }
     },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.220",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.220.tgz",
-      "integrity": "sha512-2eXZnnIgwWmXc7eRh8mRKPp6yHTKiQrLziRX/oVSfp4M6Jn2no0QFKJoHWqziF5MDQa5TF8qhD4FGsls/1nYPg==",
+      "version": "2.2.228",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.228.tgz",
+      "integrity": "sha512-ToZPI+dEz2BKj//kD2V8oXAvpeBFec5w6tXxIQh/U2iiMLcaUVZw4sxR820jF2GDArZY2D/alVkcSkId0J6rtA==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -62,15 +62,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.182.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.182.0-alpha.0.tgz",
-      "integrity": "sha512-1hEBQIz1MxZLZT/vj+GSgwmEcBoNW+6pBe54C9j4GCR3h/8uUMp8cEIkX9/nj2hYdEMOUc4675T7ctBKh4xRyw==",
+      "version": "2.185.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.185.0-alpha.0.tgz",
+      "integrity": "sha512-rR3fyUWOpUsMo7q1RBJGI1/vWxuS6apGZDKbMtpQWRKfvnqbY+cS9AeuWilPuP7Y0t3HnsQVvq46n1t9jgn00A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.182.0",
+        "aws-cdk-lib": "^2.185.0",
         "constructs": "^10.0.0"
       }
     },
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.13.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1723,9 +1723,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1003.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1003.0.tgz",
-      "integrity": "sha512-FORPDGW8oUg4tXFlhX+lv/j+152LO9wwi3/CwNr1WY3c3HwJUtc0fZGb2B3+Fzy6NhLWGHJclUsJPEhjEt8Nhg==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
+      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.182.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.182.0.tgz",
-      "integrity": "sha512-emymzTJiCpPz8oF++oiFvFuLH1QZjv6NRNQGn7VuDrEewZFTM4VpiVco5NrxH+KCWnXquDBPF5sQIUo6HY7jLg==",
+      "version": "2.185.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.185.0.tgz",
+      "integrity": "sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1757,19 +1757,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-awscli-v1": "^2.2.227",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.6.0",
+        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "^11.3.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.3",
-        "table": "^6.8.2",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -2007,7 +2007,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2340,9 +2340,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.41",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.41.tgz",
-      "integrity": "sha512-n1jD+guKd7rM19tyoNIAfjqSRDDgFe/VE0UXio64IakjUI1Pl13gQSjxmAp/5XqRvcNqIxaWrC3ohswFKU1t+w==",
+      "version": "2.35.52",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.52.tgz",
+      "integrity": "sha512-c70hiCvWkvFphHC2JySLBnHI+LF1AyZo4cp0X/lgTT2SX/pU9SxMaIrcqLEtsMLhtPssLAieocVuKWpQ5Tct0Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
@@ -4397,7 +4397,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-aurora-pgvector-extension-creator",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-pgvector-extension-creator",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@aws-cdk/aws-lambda-python-alpha": "^2.185.0-alpha.0",
         "aws-cdk-lib": "2.185.0",
@@ -4397,6 +4397,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-pgvector-extension-creator",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "bin": {
     "aws-aurora-pgvector-extension-creator": "bin/aws-aurora-pgvector-extension-creator.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.13.10",
+    "@types/node": "22.13.11",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.1003.0",
+    "aws-cdk": "2.1005.0",
     "esbuild": "^0.25.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.6",
@@ -23,15 +23,15 @@
     "typescript": "~5.8.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.182.0-alpha.0",
-    "aws-cdk-lib": "2.182.0",
-    "cdk-nag": "^2.35.41",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.185.0-alpha.0",
+    "aws-cdk-lib": "2.185.0",
+    "cdk-nag": "^2.35.52",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.1003.0",
-    "aws-cdk-lib": "2.182.0",
+    "aws-cdk": "2.1005.0",
+    "aws-cdk-lib": "2.185.0",
     "constructs": "^10.4.2"
   }
 }

--- a/src/lambdas/rds-pg-extension-init/requirements.txt
+++ b/src/lambdas/rds-pg-extension-init/requirements.txt
@@ -1,4 +1,4 @@
 aws-lambda-powertools==3.8.0
-SQLAlchemy==2.0.38
-pgvector==0.3.6
-psycopg[binary,pool]==3.2.5
+SQLAlchemy==2.0.39
+pgvector==0.4.0
+psycopg[binary,pool]==3.2.6


### PR DESCRIPTION
### **PR Type**
Dependencies

___

### **PR Description**
- Updated `aws-cdk` and related libraries to newer versions.
  - `aws-cdk` from `2.1003.0` to `2.1005.0`.
  - `aws-cdk-lib` from `2.182.0` to `2.185.0`.
  - `cdk-nag` from `2.35.41` to `2.35.52`.

- Updated `@types/node` from `22.13.10` to `22.13.11`.

- Bumped project version from `0.1.5` to `0.1.6`.
