### PR TITLE
Update cdk core-libs

### DIFF
--- a/lib/aws-aurora-pgvector-extension-endpoint-nested-stack.ts
+++ b/lib/aws-aurora-pgvector-extension-endpoint-nested-stack.ts
@@ -76,7 +76,7 @@ export class AwsAuroraPgvectorExtensionEndpointNestedStack extends NestedStack {
                 minify: true,
                 sourceMap: true,
                 sourcesContent: false,
-                esbuildVersion: '0.25.1',
+                esbuildVersion: '0.25.3',
                 target: 'ES2022',
                 format: OutputFormat.ESM,
                 forceDockerBundling: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,37 @@
 {
   "name": "aws-aurora-pgvector-extension-creator",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-pgvector-extension-creator",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
-        "@aws-cdk/aws-lambda-python-alpha": "^2.185.0-alpha.0",
-        "aws-cdk-lib": "2.185.0",
-        "cdk-nag": "^2.35.52",
+        "@aws-cdk/aws-lambda-python-alpha": "^2.192.0-alpha.0",
+        "aws-cdk-lib": "2.192.0",
+        "cdk-nag": "^2.35.82",
         "constructs": "^10.4.2",
-        "dotenv": "^16.4.7"
+        "dotenv": "^16.5.0"
       },
       "bin": {
         "aws-aurora-pgvector-extension-creator": "bin/aws-aurora-pgvector-extension-creator.js"
       },
       "devDependencies": {
-        "@tsconfig/node22": "^22.0.0",
+        "@tsconfig/node22": "^22.0.1",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.13.11",
+        "@types/node": "22.15.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.1005.0",
-        "esbuild": "^0.25.1",
+        "aws-cdk": "2.1012.0",
+        "esbuild": "^0.25.3",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.6",
+        "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
-        "typescript": "~5.8.2"
+        "typescript": "~5.8.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.1005.0",
-        "aws-cdk-lib": "2.185.0",
+        "aws-cdk": "2.1012.0",
+        "aws-cdk-lib": "2.192.0",
         "constructs": "^10.4.2"
       }
     },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.228",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.228.tgz",
-      "integrity": "sha512-ToZPI+dEz2BKj//kD2V8oXAvpeBFec5w6tXxIQh/U2iiMLcaUVZw4sxR820jF2GDArZY2D/alVkcSkId0J6rtA==",
+      "version": "2.2.233",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.233.tgz",
+      "integrity": "sha512-OH5ZN1F/0wwOUwzVUSvE0/syUOi44H9the6IG16anlSptfeQ1fvduJazZAKRuJLtautPbiqxllyOrtWh6LhX8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -62,22 +62,22 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
-      "version": "2.185.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.185.0-alpha.0.tgz",
-      "integrity": "sha512-rR3fyUWOpUsMo7q1RBJGI1/vWxuS6apGZDKbMtpQWRKfvnqbY+cS9AeuWilPuP7Y0t3HnsQVvq46n1t9jgn00A==",
+      "version": "2.192.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.192.0-alpha.0.tgz",
+      "integrity": "sha512-ezDCtT3dlIdSnJBGjwoaMJVojvk8wijmflqa0jlTspibtg1F32U/PAVdsAzlolG5gwIF1hNqiHtjW4wkyWQ3BA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.185.0",
+        "aws-cdk-lib": "^2.192.0",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
-      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
+      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
       "cpu": [
         "ppc64"
       ],
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
-      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
+      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
       "cpu": [
         "arm"
       ],
@@ -655,9 +655,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
-      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
+      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
       "cpu": [
         "arm64"
       ],
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
-      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
+      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
       "cpu": [
         "x64"
       ],
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
       "cpu": [
         "arm64"
       ],
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
-      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
+      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
       "cpu": [
         "x64"
       ],
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
       "cpu": [
         "arm64"
       ],
@@ -740,9 +740,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
-      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
+      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
       "cpu": [
         "x64"
       ],
@@ -757,9 +757,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
-      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
+      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
       "cpu": [
         "arm"
       ],
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
-      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
+      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
-      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
+      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
       "cpu": [
         "ia32"
       ],
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
-      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
+      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
       "cpu": [
         "loong64"
       ],
@@ -825,9 +825,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
-      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
+      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
       "cpu": [
         "mips64el"
       ],
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
-      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
+      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
       "cpu": [
         "ppc64"
       ],
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
-      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
+      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
       "cpu": [
         "riscv64"
       ],
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
-      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
+      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
       "cpu": [
         "s390x"
       ],
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
-      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
+      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
       "cpu": [
         "x64"
       ],
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
       "cpu": [
         "arm64"
       ],
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
       "cpu": [
         "x64"
       ],
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
       "cpu": [
         "arm64"
       ],
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
       "cpu": [
         "x64"
       ],
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
-      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
+      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
       "cpu": [
         "x64"
       ],
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
-      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
+      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
-      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
+      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
       "cpu": [
         "ia32"
       ],
@@ -1029,9 +1029,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
-      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
+      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
       "cpu": [
         "x64"
       ],
@@ -1473,9 +1473,9 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node22": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.0.tgz",
-      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.1.tgz",
+      "integrity": "sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1573,13 +1573,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
-      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
+      "version": "22.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
+      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/source-map-support": {
@@ -1723,9 +1723,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1005.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
-      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
+      "version": "2.1012.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1012.0.tgz",
+      "integrity": "sha512-C6jSWkqP0hkY2Cs300VJHjspmTXDTMfB813kwZvRbd/OsKBfTBJBbYU16VoLAp1LVEOnQMf8otSlaSgzVF0X9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.185.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.185.0.tgz",
-      "integrity": "sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==",
+      "version": "2.192.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.192.0.tgz",
+      "integrity": "sha512-Y9BAlr9a4QsEsamKc2cOGzX8DpVSOh94wsrMSGRXT0bZaqmixhhmT7WYCrT1KX4MU3gYk3OiwY2BbNyWaNE8Fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1757,9 +1757,9 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",
@@ -2340,9 +2340,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.52",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.52.tgz",
-      "integrity": "sha512-c70hiCvWkvFphHC2JySLBnHI+LF1AyZo4cp0X/lgTT2SX/pU9SxMaIrcqLEtsMLhtPssLAieocVuKWpQ5Tct0Q==",
+      "version": "2.35.82",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.82.tgz",
+      "integrity": "sha512-VKbFivqMYfmjwsnvfMM3ZmE8G/cM6krfqiKAri9iw11bqK2pdkB65UXYkqKBjroLw3sz2zdVbmoFjH2GEflWpg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
@@ -2590,9 +2590,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
-      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
+      "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2668,31 +2668,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.1",
-        "@esbuild/android-arm": "0.25.1",
-        "@esbuild/android-arm64": "0.25.1",
-        "@esbuild/android-x64": "0.25.1",
-        "@esbuild/darwin-arm64": "0.25.1",
-        "@esbuild/darwin-x64": "0.25.1",
-        "@esbuild/freebsd-arm64": "0.25.1",
-        "@esbuild/freebsd-x64": "0.25.1",
-        "@esbuild/linux-arm": "0.25.1",
-        "@esbuild/linux-arm64": "0.25.1",
-        "@esbuild/linux-ia32": "0.25.1",
-        "@esbuild/linux-loong64": "0.25.1",
-        "@esbuild/linux-mips64el": "0.25.1",
-        "@esbuild/linux-ppc64": "0.25.1",
-        "@esbuild/linux-riscv64": "0.25.1",
-        "@esbuild/linux-s390x": "0.25.1",
-        "@esbuild/linux-x64": "0.25.1",
-        "@esbuild/netbsd-arm64": "0.25.1",
-        "@esbuild/netbsd-x64": "0.25.1",
-        "@esbuild/openbsd-arm64": "0.25.1",
-        "@esbuild/openbsd-x64": "0.25.1",
-        "@esbuild/sunos-x64": "0.25.1",
-        "@esbuild/win32-arm64": "0.25.1",
-        "@esbuild/win32-ia32": "0.25.1",
-        "@esbuild/win32-x64": "0.25.1"
+        "@esbuild/aix-ppc64": "0.25.3",
+        "@esbuild/android-arm": "0.25.3",
+        "@esbuild/android-arm64": "0.25.3",
+        "@esbuild/android-x64": "0.25.3",
+        "@esbuild/darwin-arm64": "0.25.3",
+        "@esbuild/darwin-x64": "0.25.3",
+        "@esbuild/freebsd-arm64": "0.25.3",
+        "@esbuild/freebsd-x64": "0.25.3",
+        "@esbuild/linux-arm": "0.25.3",
+        "@esbuild/linux-arm64": "0.25.3",
+        "@esbuild/linux-ia32": "0.25.3",
+        "@esbuild/linux-loong64": "0.25.3",
+        "@esbuild/linux-mips64el": "0.25.3",
+        "@esbuild/linux-ppc64": "0.25.3",
+        "@esbuild/linux-riscv64": "0.25.3",
+        "@esbuild/linux-s390x": "0.25.3",
+        "@esbuild/linux-x64": "0.25.3",
+        "@esbuild/netbsd-arm64": "0.25.3",
+        "@esbuild/netbsd-x64": "0.25.3",
+        "@esbuild/openbsd-arm64": "0.25.3",
+        "@esbuild/openbsd-x64": "0.25.3",
+        "@esbuild/sunos-x64": "0.25.3",
+        "@esbuild/win32-arm64": "0.25.3",
+        "@esbuild/win32-ia32": "0.25.3",
+        "@esbuild/win32-x64": "0.25.3"
       }
     },
     "node_modules/escalade": {
@@ -4397,7 +4397,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4628,9 +4627,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
-      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
+      "version": "29.3.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
+      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4642,6 +4641,7 @@
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
+        "type-fest": "^4.39.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -4687,6 +4687,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.1.tgz",
+      "integrity": "sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-node": {
@@ -4757,9 +4770,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4771,9 +4784,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-pgvector-extension-creator",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "bin": {
     "aws-aurora-pgvector-extension-creator": "bin/aws-aurora-pgvector-extension-creator.js"
   },
@@ -11,27 +11,27 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@tsconfig/node22": "^22.0.0",
+    "@tsconfig/node22": "^22.0.1",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.13.11",
+    "@types/node": "22.15.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.1005.0",
-    "esbuild": "^0.25.1",
+    "aws-cdk": "2.1012.0",
+    "esbuild": "^0.25.3",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.6",
+    "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
-    "typescript": "~5.8.2"
+    "typescript": "~5.8.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.185.0-alpha.0",
-    "aws-cdk-lib": "2.185.0",
-    "cdk-nag": "^2.35.52",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.192.0-alpha.0",
+    "aws-cdk-lib": "2.192.0",
+    "cdk-nag": "^2.35.82",
     "constructs": "^10.4.2",
-    "dotenv": "^16.4.7"
+    "dotenv": "^16.5.0"
   },
   "peerDependencies": {
-    "aws-cdk": "2.1005.0",
-    "aws-cdk-lib": "2.185.0",
+    "aws-cdk": "2.1012.0",
+    "aws-cdk-lib": "2.192.0",
     "constructs": "^10.4.2"
   }
 }

--- a/src/lambdas/api-key-authorizer/package-lock.json
+++ b/src/lambdas/api-key-authorizer/package-lock.json
@@ -1,23 +1,23 @@
 {
     "name": "api-key-authorizer-lambda",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "api-key-authorizer-lambda",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "dependencies": {
-                "@aws-lambda-powertools/logger": "^2.16.0",
-                "@aws-sdk/client-secrets-manager": "^3.758.0",
-                "@types/aws-lambda": "^8.10.147",
+                "@aws-lambda-powertools/logger": "^2.19.0",
+                "@aws-sdk/client-secrets-manager": "^3.797.0",
+                "@types/aws-lambda": "^8.10.149",
                 "http-status-codes": "^2.3.0",
                 "util": "^0.12.5",
                 "uuid": "^11.1.0"
             },
             "devDependencies": {
                 "@types/uuid": "^10.0.0",
-                "esbuild": "^0.25.0"
+                "esbuild": "^0.25.3"
             }
         },
         "node_modules/@aws-crypto/sha256-browser": {
@@ -146,72 +146,76 @@
             }
         },
         "node_modules/@aws-lambda-powertools/commons": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.16.0.tgz",
-            "integrity": "sha512-HtVibLx8yCHvfRhOwI85ghJJqF3pYr49rZP+kRyath0ZnIEWfklFmv9ehcohPzlIgaiOijKV4vyGCKiXBOnigw==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.19.0.tgz",
+            "integrity": "sha512-WVCkcacvGX7+o/oTFs4MbFveONBOcQBmyG6MXsauSwpf3+YM5sf9MnC9oFmvA8OdQmm3yJhAAkYVFRf4tHK+aA==",
             "license": "MIT-0"
         },
         "node_modules/@aws-lambda-powertools/logger": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.16.0.tgz",
-            "integrity": "sha512-k7Xpjx1VAd/52p3Wssq83OwUFOeus6Mx9JnsXBAdAA/aUON7srbv2pPRFMGuoK9Qv5nYvADaBcL9hYtK/XknaA==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.19.0.tgz",
+            "integrity": "sha512-8Na6F6/SXUiNWH8jxoWC0VQp5TfUi/kID200yBwql6jCIm0928kHqswsWrXLv8O6W74HCdpDoXXWoyMWULR+xw==",
             "license": "MIT-0",
             "dependencies": {
-                "@aws-lambda-powertools/commons": "^2.16.0",
+                "@aws-lambda-powertools/commons": "^2.19.0",
                 "lodash.merge": "^4.6.2"
             },
             "peerDependencies": {
+                "@aws-lambda-powertools/jmespath": "2.x",
                 "@middy/core": "4.x || 5.x || 6.x"
             },
             "peerDependenciesMeta": {
+                "@aws-lambda-powertools/jmespath": {
+                    "optional": true
+                },
                 "@middy/core": {
                     "optional": true
                 }
             }
         },
         "node_modules/@aws-sdk/client-secrets-manager": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.758.0.tgz",
-            "integrity": "sha512-Vi4cdCim0jQx3rrU5R1W4v3czoWL0ajBtoI15oSSt7cwLjzNA0xq4nXSa6rahjTgtZWlLeBprbquvxNzY3qg5Q==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.797.0.tgz",
+            "integrity": "sha512-MtQrshEkyxWly4KqjEmFhB2a/RDaB5q7ow6pWmsrC3VvfUviGOY7e6ZfYypZZ4BcvUXnBBpVAtvyk0l/53t4CA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/credential-provider-node": "3.758.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.758.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.758.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.5",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-retry": "^4.0.7",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/credential-provider-node": "3.797.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.796.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.787.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.796.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.7",
-                "@smithy/util-defaults-mode-node": "^4.0.7",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
                 "@smithy/util-utf8": "^4.0.0",
                 "@types/uuid": "^9.0.1",
                 "tslib": "^2.6.2",
@@ -241,47 +245,47 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
-            "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.797.0.tgz",
+            "integrity": "sha512-9xuR918p7tShR67ZL+AOSbydpJxSHAOdXcQswxxWR/hKCF7tULX7tyL3gNo3l/ETp0CDcStvorOdH/nCbzEOjw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.758.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.758.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.5",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-retry": "^4.0.7",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.796.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.787.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.796.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.7",
-                "@smithy/util-defaults-mode-node": "^4.0.7",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -290,20 +294,20 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-            "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.796.0.tgz",
+            "integrity": "sha512-tH8Sp7lCxISVoLnkyv4AouuXs2CDlMhTuesWa0lq2NX1f+DXsMwSBtN37ttZdpFMw3F8mWdsJt27X9h2Oq868A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/core": "^3.1.5",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/signature-v4": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/signature-v4": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
                 "fast-xml-parser": "4.4.1",
                 "tslib": "^2.6.2"
             },
@@ -312,15 +316,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
-            "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.796.0.tgz",
+            "integrity": "sha512-kQzGKm4IOYYO6vUrai2JocNwhJm4Aml2BsAV+tBhFhhkutE7khf9PUucoVjB78b0J48nF+kdSacqzY+gB81/Uw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -328,20 +332,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
-            "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.796.0.tgz",
+            "integrity": "sha512-wWOT6VAHIKOuHdKFGm1iyKvx7f6+Kc/YTzFWJPuT+l+CPlXR6ylP1UMIDsHHLKpMzsrh3CH77QDsjkhQrnKkfg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.1.2",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -349,23 +353,23 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
-            "integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.797.0.tgz",
+            "integrity": "sha512-Zpj6pJ2hnebrhLDr+x61ArMUkjHG6mfJRfamHxeVTgZkhLcwHjC5aM4u9pWTVugIaPY+VBtgkKPbi3TRbHlt2g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/credential-provider-env": "3.758.0",
-                "@aws-sdk/credential-provider-http": "3.758.0",
-                "@aws-sdk/credential-provider-process": "3.758.0",
-                "@aws-sdk/credential-provider-sso": "3.758.0",
-                "@aws-sdk/credential-provider-web-identity": "3.758.0",
-                "@aws-sdk/nested-clients": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/credential-provider-env": "3.796.0",
+                "@aws-sdk/credential-provider-http": "3.796.0",
+                "@aws-sdk/credential-provider-process": "3.796.0",
+                "@aws-sdk/credential-provider-sso": "3.797.0",
+                "@aws-sdk/credential-provider-web-identity": "3.797.0",
+                "@aws-sdk/nested-clients": "3.797.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -373,22 +377,22 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
-            "integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.797.0.tgz",
+            "integrity": "sha512-xJSWvvnmzEfHbqbpN4F3E3mI9+zJ/VWLGiKOjzX1Inbspa5WqNn2GoMamolZR2TvvZS4F3Hp73TD1WoBzkIjuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.758.0",
-                "@aws-sdk/credential-provider-http": "3.758.0",
-                "@aws-sdk/credential-provider-ini": "3.758.0",
-                "@aws-sdk/credential-provider-process": "3.758.0",
-                "@aws-sdk/credential-provider-sso": "3.758.0",
-                "@aws-sdk/credential-provider-web-identity": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/credential-provider-env": "3.796.0",
+                "@aws-sdk/credential-provider-http": "3.796.0",
+                "@aws-sdk/credential-provider-ini": "3.797.0",
+                "@aws-sdk/credential-provider-process": "3.796.0",
+                "@aws-sdk/credential-provider-sso": "3.797.0",
+                "@aws-sdk/credential-provider-web-identity": "3.797.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -396,16 +400,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
-            "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.796.0.tgz",
+            "integrity": "sha512-r4e8/4AdKn/qQbRVocW7oXkpoiuXdTv0qty8AASNLnbQnT1vjD1bvmP6kp4fbHPWgwY8I9h0Dqjp49uy9Bqyuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -413,18 +417,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
-            "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.797.0.tgz",
+            "integrity": "sha512-VlyWnjTsTnBXqXcEW0nw3S7nj00n9fYwF6uU6HPO9t860yIySG01lNPAWTvAt3DfVL5SRS0GANriCZF6ohcMcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.758.0",
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/token-providers": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/client-sso": "3.797.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/token-providers": "3.797.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -432,16 +436,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
-            "integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.797.0.tgz",
+            "integrity": "sha512-DIb05FEmdOX7bNsqSVEAB3UkaDgrYHonQ2+gcBLqZ7LoDNnovHIlvC5jii93usgEStxITZstnzw+49keNEgVWw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/nested-clients": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/nested-clients": "3.797.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -449,14 +453,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+            "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -464,13 +468,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+            "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -478,14 +482,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+            "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -493,17 +497,17 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-            "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.796.0.tgz",
+            "integrity": "sha512-IeNg+3jNWT37J45opi5Jx89hGF0lOnZjiNwlMp3rKq7PlOqy8kWq5J1Gxk0W3tIkPpuf68CtBs/QFrRXWOjsZw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@smithy/core": "^3.1.5",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.787.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -511,47 +515,47 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
-            "integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.797.0.tgz",
+            "integrity": "sha512-xCsRKdsv0GAg9E28fvYBdC3JR2xdtZ2o41MVknOs+pSFtMsZm3SsgxObN35p1OTMk/o/V0LORGVLnFQMlc5QiA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.758.0",
-                "@aws-sdk/middleware-host-header": "3.734.0",
-                "@aws-sdk/middleware-logger": "3.734.0",
-                "@aws-sdk/middleware-recursion-detection": "3.734.0",
-                "@aws-sdk/middleware-user-agent": "3.758.0",
-                "@aws-sdk/region-config-resolver": "3.734.0",
-                "@aws-sdk/types": "3.734.0",
-                "@aws-sdk/util-endpoints": "3.743.0",
-                "@aws-sdk/util-user-agent-browser": "3.734.0",
-                "@aws-sdk/util-user-agent-node": "3.758.0",
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/core": "^3.1.5",
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/hash-node": "^4.0.1",
-                "@smithy/invalid-dependency": "^4.0.1",
-                "@smithy/middleware-content-length": "^4.0.1",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-retry": "^4.0.7",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@aws-sdk/core": "3.796.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.796.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.787.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.796.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
                 "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.7",
-                "@smithy/util-defaults-mode-node": "^4.0.7",
-                "@smithy/util-endpoints": "^3.0.1",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -560,16 +564,16 @@
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+            "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -577,16 +581,16 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
-            "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+            "version": "3.797.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.797.0.tgz",
+            "integrity": "sha512-TLFkP4BBdkH2zCXhG3JjaYrRft25MMZ+6/YDz1C/ikq2Zk8krUbVoSmhtYMVz10JtxAPiQ++w0vI/qbz2JSDXg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/nested-clients": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/nested-clients": "3.797.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -594,12 +598,12 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -607,14 +611,14 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.743.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "version": "3.787.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.787.0.tgz",
+            "integrity": "sha512-fd3zkiOkwnbdbN0Xp9TsP5SWrmv0SpT70YEdbb8wAj2DWQwiCmFszaSs+YCvhoCdmlR3Wl9Spu0pGpSAGKeYvQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-endpoints": "^3.0.1",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-endpoints": "^3.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -634,27 +638,27 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+            "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.758.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-            "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+            "version": "3.796.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.796.0.tgz",
+            "integrity": "sha512-9fQpNcHgVFitf1tbTT8V1xGRoRHSmOAWjrhevo6Tc0WoINMAKz+4JNqfVGWRE5Tmtpq0oHKo1RmvxXQQtJYciA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.758.0",
-                "@aws-sdk/types": "3.734.0",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@aws-sdk/middleware-user-agent": "3.796.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -670,9 +674,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
-            "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
+            "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -687,9 +691,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
-            "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
+            "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
             "cpu": [
                 "arm"
             ],
@@ -704,9 +708,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
-            "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
+            "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
             "cpu": [
                 "arm64"
             ],
@@ -721,9 +725,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
-            "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
+            "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
             "cpu": [
                 "x64"
             ],
@@ -738,9 +742,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
-            "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+            "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
             "cpu": [
                 "arm64"
             ],
@@ -755,9 +759,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
-            "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
+            "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
             "cpu": [
                 "x64"
             ],
@@ -772,9 +776,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
-            "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
+            "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
             "cpu": [
                 "arm64"
             ],
@@ -789,9 +793,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
-            "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
+            "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
             "cpu": [
                 "x64"
             ],
@@ -806,9 +810,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
-            "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
+            "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
             "cpu": [
                 "arm"
             ],
@@ -823,9 +827,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
-            "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
+            "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
             "cpu": [
                 "arm64"
             ],
@@ -840,9 +844,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
-            "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
+            "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
             "cpu": [
                 "ia32"
             ],
@@ -857,9 +861,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
-            "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
+            "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
             "cpu": [
                 "loong64"
             ],
@@ -874,9 +878,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
-            "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
+            "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
             "cpu": [
                 "mips64el"
             ],
@@ -891,9 +895,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
-            "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
+            "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
             "cpu": [
                 "ppc64"
             ],
@@ -908,9 +912,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
-            "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
+            "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
             "cpu": [
                 "riscv64"
             ],
@@ -925,9 +929,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
-            "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
+            "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
             "cpu": [
                 "s390x"
             ],
@@ -942,9 +946,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
-            "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
+            "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
             "cpu": [
                 "x64"
             ],
@@ -959,9 +963,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
-            "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
+            "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
             "cpu": [
                 "arm64"
             ],
@@ -976,9 +980,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
-            "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
+            "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
             "cpu": [
                 "x64"
             ],
@@ -993,9 +997,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
-            "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
+            "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1010,9 +1014,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
-            "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
+            "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
             "cpu": [
                 "x64"
             ],
@@ -1027,9 +1031,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
-            "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
+            "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
             "cpu": [
                 "x64"
             ],
@@ -1044,9 +1048,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
-            "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
+            "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1061,9 +1065,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
-            "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
+            "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
             "cpu": [
                 "ia32"
             ],
@@ -1078,9 +1082,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
-            "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
+            "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
             "cpu": [
                 "x64"
             ],
@@ -1095,12 +1099,12 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+            "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1108,15 +1112,15 @@
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+            "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-config-provider": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1124,17 +1128,17 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-            "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-stream": "^4.1.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-stream": "^4.2.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1143,15 +1147,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+            "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1159,14 +1163,14 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+            "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-base64": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1175,12 +1179,12 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+            "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -1190,12 +1194,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+            "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1215,13 +1219,13 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+            "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1229,18 +1233,18 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-            "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+            "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-serde": "^4.0.2",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/url-parser": "^4.0.1",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-middleware": "^4.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1248,18 +1252,18 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-            "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+            "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-middleware": "^4.0.1",
-                "@smithy/util-retry": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
                 "tslib": "^2.6.2",
                 "uuid": "^9.0.1"
             },
@@ -1281,12 +1285,12 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+            "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1294,12 +1298,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+            "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1307,14 +1311,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+            "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/shared-ini-file-loader": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1322,15 +1326,15 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-            "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+            "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/querystring-builder": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/abort-controller": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1338,12 +1342,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1351,12 +1355,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+            "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1364,12 +1368,12 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+            "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-uri-escape": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1378,12 +1382,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+            "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1391,24 +1395,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+            "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0"
+                "@smithy/types": "^4.2.0"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+            "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1416,16 +1420,16 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.0.tgz",
+            "integrity": "sha512-4t5WX60sL3zGJF/CtZsUQTs3UrZEDO2P7pEaElrekbLqkWPYkgqNW1oeiNYC6xXifBnT9dVBOnNQRvOE9riU9w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-hex-encoding": "^4.0.0",
-                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.2",
                 "@smithy/util-uri-escape": "^4.0.0",
                 "@smithy/util-utf8": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -1435,17 +1439,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-            "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+            "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.1.5",
-                "@smithy/middleware-endpoint": "^4.0.6",
-                "@smithy/middleware-stack": "^4.0.1",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/types": "^4.1.0",
-                "@smithy/util-stream": "^4.1.2",
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1453,9 +1457,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -1465,13 +1469,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+            "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/querystring-parser": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1542,14 +1546,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-            "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+            "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -1558,17 +1562,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-            "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+            "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.0.1",
-                "@smithy/credential-provider-imds": "^4.0.1",
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/property-provider": "^4.0.1",
-                "@smithy/smithy-client": "^4.1.6",
-                "@smithy/types": "^4.1.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1576,13 +1580,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+            "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1602,12 +1606,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+            "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.1.0",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1615,13 +1619,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+            "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.0.1",
-                "@smithy/types": "^4.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/types": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1629,14 +1633,14 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-            "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+            "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.0.1",
-                "@smithy/node-http-handler": "^4.0.3",
-                "@smithy/types": "^4.1.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/types": "^4.2.0",
                 "@smithy/util-base64": "^4.0.0",
                 "@smithy/util-buffer-from": "^4.0.0",
                 "@smithy/util-hex-encoding": "^4.0.0",
@@ -1673,9 +1677,9 @@
             }
         },
         "node_modules/@types/aws-lambda": {
-            "version": "8.10.147",
-            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
-            "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+            "version": "8.10.149",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
+            "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
             "license": "MIT"
         },
         "node_modules/@types/uuid": {
@@ -1815,9 +1819,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
-            "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
+            "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -1828,31 +1832,31 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.0",
-                "@esbuild/android-arm": "0.25.0",
-                "@esbuild/android-arm64": "0.25.0",
-                "@esbuild/android-x64": "0.25.0",
-                "@esbuild/darwin-arm64": "0.25.0",
-                "@esbuild/darwin-x64": "0.25.0",
-                "@esbuild/freebsd-arm64": "0.25.0",
-                "@esbuild/freebsd-x64": "0.25.0",
-                "@esbuild/linux-arm": "0.25.0",
-                "@esbuild/linux-arm64": "0.25.0",
-                "@esbuild/linux-ia32": "0.25.0",
-                "@esbuild/linux-loong64": "0.25.0",
-                "@esbuild/linux-mips64el": "0.25.0",
-                "@esbuild/linux-ppc64": "0.25.0",
-                "@esbuild/linux-riscv64": "0.25.0",
-                "@esbuild/linux-s390x": "0.25.0",
-                "@esbuild/linux-x64": "0.25.0",
-                "@esbuild/netbsd-arm64": "0.25.0",
-                "@esbuild/netbsd-x64": "0.25.0",
-                "@esbuild/openbsd-arm64": "0.25.0",
-                "@esbuild/openbsd-x64": "0.25.0",
-                "@esbuild/sunos-x64": "0.25.0",
-                "@esbuild/win32-arm64": "0.25.0",
-                "@esbuild/win32-ia32": "0.25.0",
-                "@esbuild/win32-x64": "0.25.0"
+                "@esbuild/aix-ppc64": "0.25.3",
+                "@esbuild/android-arm": "0.25.3",
+                "@esbuild/android-arm64": "0.25.3",
+                "@esbuild/android-x64": "0.25.3",
+                "@esbuild/darwin-arm64": "0.25.3",
+                "@esbuild/darwin-x64": "0.25.3",
+                "@esbuild/freebsd-arm64": "0.25.3",
+                "@esbuild/freebsd-x64": "0.25.3",
+                "@esbuild/linux-arm": "0.25.3",
+                "@esbuild/linux-arm64": "0.25.3",
+                "@esbuild/linux-ia32": "0.25.3",
+                "@esbuild/linux-loong64": "0.25.3",
+                "@esbuild/linux-mips64el": "0.25.3",
+                "@esbuild/linux-ppc64": "0.25.3",
+                "@esbuild/linux-riscv64": "0.25.3",
+                "@esbuild/linux-s390x": "0.25.3",
+                "@esbuild/linux-x64": "0.25.3",
+                "@esbuild/netbsd-arm64": "0.25.3",
+                "@esbuild/netbsd-x64": "0.25.3",
+                "@esbuild/openbsd-arm64": "0.25.3",
+                "@esbuild/openbsd-x64": "0.25.3",
+                "@esbuild/sunos-x64": "0.25.3",
+                "@esbuild/win32-arm64": "0.25.3",
+                "@esbuild/win32-ia32": "0.25.3",
+                "@esbuild/win32-x64": "0.25.3"
             }
         },
         "node_modules/fast-xml-parser": {

--- a/src/lambdas/api-key-authorizer/package.json
+++ b/src/lambdas/api-key-authorizer/package.json
@@ -1,16 +1,16 @@
 {
     "name": "api-key-authorizer-lambda",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "dependencies": {
-        "@aws-lambda-powertools/logger": "^2.16.0",
-        "@aws-sdk/client-secrets-manager": "^3.758.0",
-        "@types/aws-lambda": "^8.10.147",
+        "@aws-lambda-powertools/logger": "^2.19.0",
+        "@aws-sdk/client-secrets-manager": "^3.797.0",
+        "@types/aws-lambda": "^8.10.149",
         "http-status-codes": "^2.3.0",
         "util": "^0.12.5",
         "uuid": "^11.1.0"
     },
     "devDependencies": {
         "@types/uuid": "^10.0.0",
-        "esbuild": "^0.25.0"
+        "esbuild": "^0.25.3"
     }
 }

--- a/src/lambdas/rds-pg-extension-init/requirements.txt
+++ b/src/lambdas/rds-pg-extension-init/requirements.txt
@@ -1,4 +1,4 @@
-aws-lambda-powertools==3.8.0
-SQLAlchemy==2.0.39
-pgvector==0.4.0
+aws-lambda-powertools==3.11.0
+SQLAlchemy==2.0.40
+pgvector==0.4.1
 psycopg[binary,pool]==3.2.6


### PR DESCRIPTION
### **PR Type**
Dependencies, Enhancement

___

### **PR Description**
- Updated core AWS CDK and related library dependencies.
  - Updated `aws-cdk` from `2.1005.0` to `2.1012.0`.
  - Updated `aws-cdk-lib` from `2.185.0` to `2.192.0`.
  - Updated `@aws-cdk/aws-lambda-python-alpha` from `2.185.0-alpha.0` to `2.192.0-alpha.0`.
  - Updated `cdk-nag` from `2.35.52` to `2.35.82`.
  - Updated `esbuild` from `0.25.1` to `0.25.3` and related bundling config.
  - Updated `@tsconfig/node22`, `@types/node`, `ts-jest`, and `typescript` to latest versions.

- Updated Lambda authorizer and extension Lambda dependencies.
  - Updated `@aws-lambda-powertools/logger` from `2.16.0` to `2.19.0`.
  - Updated `@aws-sdk/client-secrets-manager` from `3.758.0` to `3.797.0`.
  - Updated `@types/aws-lambda` from `8.10.147` to `8.10.149`.
  - Updated `esbuild` in Lambda dev dependencies.

- Updated Python Lambda requirements for extension initialization.
  - Updated `aws-lambda-powertools` from `3.8.0` to `3.11.0`.
  - Updated `SQLAlchemy` from `2.0.39` to `2.0.40`.
  - Updated `pgvector` from `0.4.0` to `0.4.1`.

- Incremented project and Lambda package versions to reflect updates.
